### PR TITLE
Feat: use .eleventyignore

### DIFF
--- a/.eleventyignore
+++ b/.eleventyignore
@@ -1,0 +1,3 @@
+LICENSE.md
+README.md
+README_ja_JP.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches: [develop]
     types: [closed]
     paths:
+      - '.eleventyignore'
       - '**.html'
       - '**.css'
       - '**.js'


### PR DESCRIPTION
Ignore readmes and license files. Also add `.eleventyignore` to the
Github Workflows trigger paths, since changes to the file probably
change the website output.

Issue: #1